### PR TITLE
Add a script to retrieve comps ids from a suite ID

### DIFF
--- a/simulations/get_depends_on_ids_from_suite.py
+++ b/simulations/get_depends_on_ids_from_suite.py
@@ -23,12 +23,15 @@ def get_depends_on_ids(suite_ids: str) -> str:
     site_to_ids = {"site": [],
                    "exp_id": [],
                    "analyzer_wi_id": [],
-                   "filter_wi_id": []}
+                   "filter_wi_id": [],
+                   "date_created": []}
     for exp in suite.experiments:
         exp_id = exp.id
         site_name = exp.name[len("validation_"):]
+        date_created = exp._platform_object.date_created
         site_to_ids["site"].append(site_name)
         site_to_ids["exp_id"].append(exp_id)
+        site_to_ids["date_created"].append(date_created)
 
         e = Experiment.get(exp_id)
         analyzer_wi = e.get_parent_related_workitems(relation_type=RelationType.DependsOn)


### PR DESCRIPTION
change for #28. Automatically get suite id from COMPS_ID folder id and retrieve all related experiments and work items ids and save in a csv file.
file name: "suite_{suite_id}.csv", for example: "suite_523fb2ef-3009-ed11-a9fa-b88303911bc1.csv".
![image](https://user-images.githubusercontent.com/19782371/200967116-84723fa2-ec5b-4cfc-8bff-e4ec6e4efcdc.png)

