### PR TITLE
Update requirements.txt: use scikit-learn instead of sklearn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ idmtools-cli~=1.6.4
 emodpy-malaria~=2.0
 fpdf2
 seaborn
-sklearn
+scikit-learn
 scipy
 snakemake
 plotnine


### PR DESCRIPTION
https://pypi.org/project/sklearn/
sklearn package is deprecated in PyPI since Nov. 7 2022.