### PR TITLE
use double brackets to select columns

### DIFF
--- a/simulations/analyzers/AnnualSummaryReportAnalyzer.py
+++ b/simulations/analyzers/AnnualSummaryReportAnalyzer.py
@@ -78,8 +78,8 @@ class AnnualSummaryReportAnalyzer(BaseAnalyzer):
 
         groupby_tags = self.sweep_variables
         groupby_tags.remove('Run_Number')
-        df_summarized = df_final.groupby(['Age']+groupby_tags)['Prevalence', 'Incidence'].apply(np.mean).reset_index()
-        df_summarized_std = df_final.groupby(['Age']+groupby_tags)['Prevalence', 'Incidence'].apply(np.std)
+        df_summarized = df_final.groupby(['Age']+groupby_tags)[['Prevalence', 'Incidence']].apply(np.mean).reset_index()
+        df_summarized_std = df_final.groupby(['Age']+groupby_tags)[['Prevalence', 'Incidence']].apply(np.std)
         for c in ['Prevalence', 'Incidence']:
             df_summarized[c + '_std'] = list(df_summarized_std[c])
 

--- a/simulations/analyzers/AnnualSummaryReportAnalyzer.py
+++ b/simulations/analyzers/AnnualSummaryReportAnalyzer.py
@@ -78,8 +78,8 @@ class AnnualSummaryReportAnalyzer(BaseAnalyzer):
 
         groupby_tags = self.sweep_variables
         groupby_tags.remove('Run_Number')
-        df_summarized = df_final.groupby(['Age']+groupby_tags)[['Prevalence', 'Incidence']].apply(np.mean).reset_index()
-        df_summarized_std = df_final.groupby(['Age']+groupby_tags)[['Prevalence', 'Incidence']].apply(np.std)
+        df_summarized = df_final.groupby(['Age']+groupby_tags)[['Prevalence', 'Incidence']].apply(np.mean, axis=0).reset_index()
+        df_summarized_std = df_final.groupby(['Age']+groupby_tags)[['Prevalence', 'Incidence']].apply(np.std, axis=0)
         for c in ['Prevalence', 'Incidence']:
             df_summarized[c + '_std'] = list(df_summarized_std[c])
 


### PR DESCRIPTION
Closes #61 for sotuba_1999 by using double brackets to select pandas dataframe columns (require for >=2.0.0). See this [thread](https://stackoverflow.com/questions/76158147/pandas-groupby-valueerror-cannot-subset-columns-with-a-tuple-with-more-than-o). 

Some analyzers are still failing and I will put in a new issue documenting these.